### PR TITLE
Made a few changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "cd tests && npx ts-node-dev --respawn server.ts"
   },
   "dependencies": {
+    "has-pkg": "^0.0.1",
     "nodemailer": "^6.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test": "cd tests && npx ts-node-dev --respawn server.ts"
   },
   "dependencies": {
-    "has-pkg": "^0.0.1",
+    "local-pkg": "^0.4.0",
     "nodemailer": "^6.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
   "license": "MIT",
   "private": false,
   "scripts": {
+    "watch": "npx tsc --watch",
     "prepublishOnly": "npx tsc",
-    "test": "npx tsc && cd tests && npx ts-node-dev --respawn server.ts"
+    "test": "cd tests && npx ts-node-dev --respawn server.ts"
   },
   "dependencies": {
     "nodemailer": "^6.7.0"
@@ -19,6 +20,7 @@
     "@aws-sdk/client-ses": "^3.36.1",
     "@types/nodemailer": "^6.4.4",
     "postmark": "^2.7.8",
+    "typescript": "^4.4.4",
     "xpresser": "^0.23.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
     "test": "npx tsc && cd tests && npx ts-node-dev --respawn server.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-ses": "^3.36.1",
-    "nodemailer": "^6.7.0",
-    "postmark": "^2.7.8"
+    "nodemailer": "^6.7.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-ses": "^3.36.1",
     "@types/nodemailer": "^6.4.4",
-    "xpresser": "^0.22.3"
+    "postmark": "^2.7.8",
+    "xpresser": "^0.23.2"
   }
 }

--- a/plugin-index.ts
+++ b/plugin-index.ts
@@ -1,5 +1,5 @@
 import { DollarSign } from "xpresser/types";
-import hasPkg from "has-pkg";
+import { isPackageExists } from "local-pkg";
 
 
 export function run(plugin: any, $: DollarSign) {
@@ -28,7 +28,7 @@ export function run(plugin: any, $: DollarSign) {
         }
 
         if (provider === "AWS") {
-            if (!hasPkg("@aws-sdk/client-ses")) {
+            if (!isPackageExists("@aws-sdk/client-ses")) {
                 $.logWarning(`Package {@aws-sdk/client-ses} is required for AWS`);
                 return $.logErrorAndExit("Install missing package and restart server!");
             }

--- a/plugin-index.ts
+++ b/plugin-index.ts
@@ -1,4 +1,5 @@
 import { DollarSign } from "xpresser/types";
+import hasPkg from "has-pkg";
 
 
 export function run(plugin: any, $: DollarSign) {
@@ -27,6 +28,11 @@ export function run(plugin: any, $: DollarSign) {
         }
 
         if (provider === "AWS") {
+            if (!hasPkg("@aws-sdk/client-ses")) {
+                $.logWarning(`Package {@aws-sdk/client-ses} is required for AWS`);
+                return $.logErrorAndExit("Install missing package and restart server!");
+            }
+
             let requiredFields = [
                 "region",
                 "fromEmail",

--- a/plugin-index.ts
+++ b/plugin-index.ts
@@ -1,37 +1,47 @@
 import { DollarSign } from "xpresser/types";
 
-const packageName = "mailer";
 
 export function run(plugin: any, $: DollarSign) {
+    const packageName = plugin.namespace;
+
     $.ifNotConsole(() => {
+        // Check package config
         if (!$.config.has(packageName)) {
-            return $.logErrorAndExit(`Config "maiiler" is required!`);
+            return $.logErrorAndExit(`Config ${packageName}" is required!`);
         }
+
+        // Validate package config.
         const config = $.config.path(packageName);
 
-        if (!config.has("provider")) {
+        // Get provider
+        const provider = config.get("provider") as string | undefined;
+        if (!provider) {
             return $.logErrorAndExit(`"provider" is required in config: "${packageName}"`);
         }
 
-        if (!config.get("provider").match(/^(AWS|SMTP)$/)) {
+        // validate provider.
+        if (!provider.match(/^(AWS|SMTP)$/)) {
             return $.logErrorAndExit(
                 `"${config.get("provider")}" is not a valid provider {SMTP | AWS}`
             );
         }
 
-        if (config.get("provider") === "AWS") {
+        if (provider === "AWS") {
             let requiredFields = [
                 "region",
                 "fromEmail",
                 "AWS_SECRET_ACCESS_KEY",
                 "AWS_ACCESS_KEY_ID"
             ];
+
             requiredFields.forEach((value) => {
                 if (!config.get(value)) {
                     return $.logErrorAndExit(`mailer {${value}} is missing!`);
                 }
             });
+
         } else {
+
             let requiredFields = ["host", "port", "username", "password", "fromEmail"];
 
             requiredFields.forEach((value) => {

--- a/plugin-index.ts
+++ b/plugin-index.ts
@@ -40,7 +40,5 @@ export function run(plugin: any, $: DollarSign) {
                 }
             });
         }
-
-        require("./index");
     });
 }


### PR DESCRIPTION
I made a few changes to be applied for now.

Made `nodemailer` the only dependency. The rest are all dev dependencies. This means if someone wants to use aws they will install the aws package.

I also added a package `has-pkg` by @antfu  that checks if the required aws package i.e `@aws-sdk/client-ses` is installed. I may add this function to xpresser's plugin ecosystem in the nearest future.

E.g plugin-index.ts 
```ts
// Xpresser will run this function before the plugin run function
// any package returned in the array will be checked.
export function dependsOn($: DollarSign) {
  const provider = $.config.get('path.provider.config');
 
  return provider === "AWS" ? ["@aws-sdk/client-ses"] : []
}
```